### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Run tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:
@@ -20,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Run tests
 on:
   push:
   pull_request:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Run tests
 on:
   push:
   pull_request:
-  pull_request:
 
 jobs:
   test:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "symfony/process": "^6.0|^7.0"
     },
     "require-dev": {
-        "spatie/laravel-backup": "^9.0",
+        "spatie/laravel-backup": "^10.0",
         "laravel/laravel": "^10.0|^11.0|^12.0|^13.0",
         "phpunit/phpunit": "^10.0|^11.0",
         "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
     },
     "require-dev": {
         "spatie/laravel-backup": "^10.0",
-        "laravel/laravel": "^10.0|^11.0|^12.0|^13.0",
+        "laravel/laravel": "^12.0|^13.0",
         "phpunit/phpunit": "^10.0|^11.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "mockery/mockery": "^1.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
     },
     "require-dev": {
         "spatie/laravel-backup": "^9.0",
-        "laravel/laravel": "^10.0|^11.0|^12.0",
+        "laravel/laravel": "^10.0|^11.0|^12.0|^13.0",
         "phpunit/phpunit": "^10.0|^11.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- add Laravel 13 support to dev dependencies
- add Testbench 11 support
- add `pull_request` trigger to the test workflow
- add Laravel 13 and PHP 8.5 to the CI matrix

## Testing
- composer update
- vendor/bin/phpunit

## Notes
- local reproduction in this environment does not include the workflow's MySQL service, so package tests that rely on the DB-backed backup check need GitHub Actions for the authoritative run
